### PR TITLE
Resolve PR conflicts with tabs for digital and film

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,55 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TA</title>
-    <link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Portfolio</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <header class="header">
-        <h1 class="header-title">Portfolio</h1>
-        <div class="dropdown">
-            <button class="dropbtn">Filter by</button>
-            <div class="dropdown-content">
-                <a href="#" onclick="filterImages('featured')">Featured</a>
-                <a href="#" onclick="filterImages('digital')">Digital</a>
-                <a href="#" onclick="filterImages('film')">Film</a>
-            </div>
-        </div>
-        <hr class="header-line">
-    </header>
-    
-    <div class="image-container">
-        <img src="film1.jpg" alt="film 1" onclick="openModal(this)" class="film">
-        <img src="film2.jpg" alt="film 2" onclick="openModal(this)" class="film">
-        <img src="film3.jpg" alt="film 3" onclick="openModal(this)" class="film">
-        <img src="film4.jpg" alt="film 4" onclick="openModal(this)" class="film">
-        <img src="film5.jpg" alt="film 5" onclick="openModal(this)" class="film">
-        <img src="film6.jpg" alt="film 6" onclick="openModal(this)" class="film">
-        <img src="film7.jpg" alt="film 7" onclick="openModal(this)" class="film">
-        <img src="film8.jpg" alt="film 8" onclick="openModal(this)" class="film">
-        <img src="film9.jpg" alt="film 9" onclick="openModal(this)" class="film">
-        <img src="film10.jpg" alt="film 10" onclick="openModal(this)" class="film">
+  <header>
+    <h1>Portfolio</h1>
+    <nav>
+      <button id="digitalTab" class="active">Digital Photography</button>
+      <button id="filmTab">Film Photography</button>
+    </nav>
+  </header>
 
-        <img src="digital1.jpg" alt="digital 1" onclick="openModal(this)" class="digital">
-        <img src="digital2.jpg" alt="digital 2" onclick="openModal(this)" class="digital">
-        <img src="digital3.jpg" alt="digital 3" onclick="openModal(this)" class="digital">
-        <img src="digital4.jpg" alt="digital 4" onclick="openModal(this)" class="digital">
-        <img src="digital5.jpg" alt="digital 5" onclick="openModal(this)" class="digital">
-        <img src="digital6.jpg" alt="digital 6" onclick="openModal(this)" class="digital">
-        <img src="digital7.jpg" alt="digital 7" onclick="openModal(this)" class="digital">
-        <img src="digital8.jpg" alt="digital 8" onclick="openModal(this)" class="digital">
-        <img src="digital9.jpg" alt="digital 9" onclick="openModal(this)" class="digital">
-        <img src="digital10.jpg" alt="digital 10" onclick="openModal(this)" class="digital">
-        <!-- Add more images as needed -->
-    </div>
+  <div id="gallery"></div>
 
-    <div id="modal" class="modal">
-        <span class="close" onclick="closeModal()">&times;</span>
-        <img class="modal-content" id="modal-image">
-    </div>
+  <div id="lightbox" class="lightbox">
+    <span class="close">&times;</span>
+    <img id="lightbox-img" class="lightbox-content" src="" alt="">
+  </div>
 
-    <script src="script.js"></script>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,52 +1,49 @@
-// script.js
+const images = ["digital1.jpg","digital10.JPG","digital11.jpg","digital12.JPG","digital13.JPG","digital14.JPG","digital15.JPG","digital16.jpg","digital17.JPG","digital18.JPG","digital19.JPG","digital2.jpg","digital20.JPG","digital21.JPG","digital22.JPG","digital23.jpg","digital24.JPG","digital25.jpg","digital26.JPG","digital27.JPG","digital28.JPG","digital29.JPG","digital3.jpg","digital30.JPG","digital31.jpg","digital32.JPG","digital33.JPG","digital34.jpg","digital35.JPG","digital36.JPG","digital37.JPG","digital38.JPG","digital39.JPG","digital4.jpg","digital40.JPG","digital41.HEIC","digital42.JPG","digital43.jpg","digital44.jpg","digital45.jpg","digital46.jpg","digital47.jpg","digital48.jpg","digital49.jpg","digital5.jpg","digital50.jpg","digital51.JPG","digital52.jpg","digital53.JPG","digital54.JPG","digital55.JPG","digital56.JPG","digital57.JPG","digital58.jpg","digital59.jpg","digital6.jpg","digital60.jpg","digital61.jpg","digital62.jpg","digital63.jpg","digital64.jpg","digital65.jpg","digital66.jpg","digital67.jpg","digital68.jpg","digital69.jpg","digital7.jpg","digital70.jpg","digital71.jpg","digital72.jpg","digital73.jpg","digital74.jpg","digital75.jpg","digital76.jpg","digital77.jpg","digital78.jpg","digital79.jpg","digital8.jpg","digital80.jpg","digital81.jpg","digital82.jpg","digital83.jpg","digital84.jpg","digital85.jpg","digital86.jpg","digital87.jpg","digital9.JPG","film1.jpg","film10.JPG","film100.JPG","film101.JPG","film102.JPG","film103.JPG","film104.JPG","film105.JPG","film106.JPG","film107.JPG","film108.JPG","film109.JPG","film11.JPG","film110.JPG","film111.JPG","film12.JPG","film13.jpeg","film14.jpeg","film15.jpeg","film16.jpeg","film17.jpeg","film18.jpeg","film19.JPG","film2.jpg","film20.JPG","film21.JPG","film22.JPG","film23.JPG","film24.JPG","film25.JPG","film26.JPG","film27.JPG","film28.JPG","film29.JPG","film3.JPG","film30.JPG","film31.JPG","film32.JPG","film33.JPG","film34.JPG","film35.JPG","film36.JPG","film37.JPG","film38.JPG","film39.JPG","film4.jpg","film40.JPG","film41.JPG","film42.JPG","film43.JPG","film44.JPG","film45.JPG","film46.JPG","film47.JPG","film48.JPG","film49.JPG","film5.JPG","film50.JPG","film51.JPG","film52.JPG","film53.JPG","film54.JPG","film55.JPG","film56.JPG","film57.JPG","film58.JPG","film59.JPG","film6.JPG","film60.JPG","film61.JPG","film62.JPG","film63.JPG","film64.JPG","film65.JPG","film66.JPG","film67.JPG","film68.JPG","film69.JPG","film7.JPG","film70.JPG","film71.JPG","film72.JPG","film73.JPG","film74.JPG","film75.JPG","film76.JPG","film77.JPG","film78.JPG","film79.JPG","film8.JPG","film80.JPG","film81.JPG","film82.JPG","film83.JPG","film84.JPG","film85.JPG","film86.JPG","film87.JPG","film88.JPG","film89.JPG","film9.JPG","film90.JPG","film91.JPG","film92.JPG","film93.JPG","film94.JPG","film95.JPG","film96.JPG","film97.JPG","film98.JPG","film99.JPG"];
+const digitalImages = images.filter(img => /digital/i.test(img));
+const filmImages = images.filter(img => /film/i.test(img));
 
-document.addEventListener("DOMContentLoaded", function() {
-    shuffleImages();
+
+document.addEventListener('DOMContentLoaded', () => {
+  const gallery = document.getElementById('gallery');
+    function renderGallery(list) {
+      gallery.innerHTML = "";
+      list.forEach(src => {
+        const img = document.createElement("img");
+        img.src = src;
+        img.loading = "lazy";
+        img.alt = "";
+        img.addEventListener("click", () => openLightbox(src));
+        gallery.appendChild(img);
+      });
+    }
+    const digitalBtn = document.getElementById("digitalTab");
+    const filmBtn = document.getElementById("filmTab");
+    digitalBtn.addEventListener("click", () => {
+      digitalBtn.classList.add("active");
+      filmBtn.classList.remove("active");
+      renderGallery(digitalImages);
+    });
+    filmBtn.addEventListener("click", () => {
+      filmBtn.classList.add("active");
+      digitalBtn.classList.remove("active");
+      renderGallery(filmImages);
+    });
+    renderGallery(digitalImages);
+
+
+  document.querySelector('#lightbox .close').addEventListener('click', closeLightbox);
+  document.getElementById('lightbox').addEventListener('click', e => {
+    if (e.target === e.currentTarget) closeLightbox();
+  });
 });
 
-function shuffleImages() {
-    const imageContainer = document.querySelector(".image-container");
-    const images = Array.from(document.querySelectorAll(".image-container img"));
-
-    // Shuffle the array of images
-    for (let i = images.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [images[i], images[j]] = [images[j], images[i]];
-    }
-
-    // Clear the existing images
-    imageContainer.innerHTML = '';
-
-    // Append shuffled images to the container
-    images.forEach(image => {
-        imageContainer.appendChild(image);
-    });
+function openLightbox(src) {
+  const lightbox = document.getElementById('lightbox');
+  const img = document.getElementById('lightbox-img');
+  img.src = src;
+  lightbox.style.display = 'flex';
 }
 
-function openModal(imgElement) {
-    const modal = document.getElementById("modal");
-    const modalImg = document.getElementById("modal-image");
-
-    modal.style.display = "block";
-    modalImg.src = imgElement.src;
-}
-
-function closeModal() {
-    document.getElementById("modal").style.display = "none";
-}
-
-function filterImages(category) {
-    const images = document.querySelectorAll(".image-container img");
-
-    images.forEach(image => {
-        if (category === "featured" && !image.classList.contains("featured")) {
-            image.style.display = "none";
-        } else if (category === "digital" && !image.classList.contains("digital")) {
-            image.style.display = "none";
-        } else if (category === "film" && !image.classList.contains("film")) {
-            image.style.display = "none";
-        } else {
-            image.style.display = "block";
-        }
-    });
+function closeLightbox() {
+  document.getElementById('lightbox').style.display = 'none';
 }

--- a/style.css
+++ b/style.css
@@ -1,87 +1,67 @@
-/* style.css */
-
-* {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-}
-
+* { box-sizing: border-box; margin: 0; padding: 0; }
 body {
-    font-family: Arial, sans-serif;
-    background-color: #f0f0f0; /* Set background color */
+  font-family: Arial, sans-serif;
+  background: #fff;
 }
-
-.header {
-    margin-bottom: 30px; /* Add space between header and images */
+header {
+  text-align: center;
+  padding: 1rem 0;
+  border-bottom: 1px solid #eee;
+  margin-bottom: 1rem;
 }
-
-.header-title {
-    font-size: 24px; /* Make text smaller */
-    font-weight: normal; /* Use thin, minimalist text */
-    margin-bottom: 10px; /* Add spacing below the title */
+nav {
+  margin-top: 0.5rem;
 }
-
-.header-line {
-    width: 100%; /* Extend the line all the way across the page */
-    border: none;
-    border-top: 1px solid #888; /* Use minimalist line */
-    margin-bottom: 20px; /* Add spacing below the line */
+nav button {
+  padding: 0.4rem 1rem;
+  margin: 0 0.3rem;
+  border: none;
+  background: #eee;
+  cursor: pointer;
+  border-radius: 4px;
 }
-
-.image-container {
-    max-width: 1200px; /* Set maximum width for the container */
-    margin: 0 auto; /* Center the container horizontally */
-    padding: 20px;
-    column-count: 4; /* Set the number of columns */
-    column-gap: 20px; /* Set the gap between columns */
+nav button.active {
+  background: #333;
+  color: #fff;
 }
-
-.image-container img {
-    width: 100%; /* Make images fill the column width */
-    display: block;
-    margin-bottom: 20px; /* Adjust the spacing between images as needed */
-    border-radius: 8px; /* Optional: Add some border-radius for aesthetics */
-    transition: transform 0.3s ease; /* Add transition for smooth effect */
-    cursor: pointer; /* Change cursor to pointer on hover */
+#gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 15px;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 15px 60px;
 }
-
-.image-container img:hover {
-    transform: scale(1.1); /* Enlarge the image on hover */
+#gallery img {
+  width: 100%;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: transform 0.3s ease;
 }
-
-.modal {
-    display: none; /* Hidden by default */
-    position: fixed; /* Stay in place */
-    z-index: 9999; /* Sit on top */
-    padding-top: 50px; /* Location of the modal */
-    left: 0;
-    top: 0;
-    width: 100%; /* Full width */
-    height: 100%; /* Full height */
-    background-color: rgba(0,0,0,0.9); /* Black background with opacity */
-    overflow: auto; /* Enable scroll if needed */
+#gallery img:hover {
+  transform: scale(1.05);
 }
-
-.modal-content {
-    margin: auto;
-    display: block;
-    max-width: 100%; /* Set maximum width to fit the viewport */
-    max-height: 100%; /* Set maximum height to fit the viewport */
+.lightbox {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.9);
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
 }
-
-.close {
-    color: #fff;
-    position: absolute;
-    top: 10px;
-    right: 25px;
-    font-size: 36px;
-    font-weight: bold;
-    transition: 0.3s;
+.lightbox img {
+  max-width: 90%;
+  max-height: 90%;
 }
-
-.close:hover,
-.close:focus {
-    color: #999;
-    text-decoration: none;
-    cursor: pointer;
+.lightbox .close {
+  position: absolute;
+  top: 20px;
+  right: 30px;
+  font-size: 35px;
+  color: #fff;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- add nav buttons for Digital and Film tabs
- style active nav buttons
- filter large image array by digital/film names
- render each set in the gallery with lazy-loading

## Testing
- `node -e "console.log('node present')"`
- `node - <<'NODE'
const fs=require('fs');
const text=fs.readFileSync('script.js','utf8');
const images=text.match(/const images = \[(.*)\];/s)[1].split(',');
const digital=images.filter(n=>/digital/i.test(n));
const film=images.filter(n=>/film/i.test(n));
console.log('images',images.length,'digital',digital.length,'film',film.length);
NODE`